### PR TITLE
Extended Window Features

### DIFF
--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -15,6 +15,8 @@ from nltk.tokenize import word_tokenize
 Token: TypeAlias = Tuple[str, int, int]
 EntitySpan: TypeAlias = Tuple[int, int, str]
 
+nltk.download("averaged_perceptron_tagger_eng")
+
 
 def tokenize(txt: str):
     """

--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -16,6 +16,7 @@ Token: TypeAlias = Tuple[str, int, int]
 EntitySpan: TypeAlias = Tuple[int, int, str]
 
 nltk.download("averaged_perceptron_tagger_eng")
+nltk.download("universal_tagset")
 
 
 def tokenize(txt: str):

--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -9,6 +9,7 @@ from typing import List, Tuple, TypeAlias
 from xml.dom.minidom import parse
 
 import nltk
+import nltk.tag
 from nltk.tokenize import word_tokenize
 
 Token: TypeAlias = Tuple[str, int, int]
@@ -69,8 +70,9 @@ def extract_features(tokens: List[Token]):
 
     # for each token, generate list of features and add it to the result
     result: List[List[str]] = []
-    for k, token in enumerate(tokens):
-        word, start, end = token  # Unpack the token tuple
+    pos_tags = nltk.tag.pos_tag([t[0] for t in tokens], tagset="universal")  # Get POS tags for the tokens
+    assert len(tokens) == len(pos_tags), "Mismatch between tokens and POS tags length"
+    for k, (word, pos_tag) in enumerate(pos_tags):
         features: List[str] = []
 
         features.append("form=" + word)  # Token form
@@ -87,6 +89,7 @@ def extract_features(tokens: List[Token]):
         features.append("hashyphen=" + str("-" in word))  # Does the token contain a hyphen?
         features.append("length=" + str(len(word)))  # Length of the token
         features.append("form_lower=" + word.lower())  # Lowercase form of the token
+        features.append("pos_tag=" + pos_tag)  # POS tag of the token
 
         if k > 0:
             tPrev = tokens[k - 1][0]

--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -111,7 +111,7 @@ def extract_features(tokens: List[Token]):
             window_word = tokens[k + i][0]
             if i != 0:
                 features.append("window" + str(i) + "=" + window_word.lower())  # Context window features
-                features.append("window-" + str(i) + "-size=" + str(len(window_word)))  # Size of the context window
+                features.append("window" + str(i) + "-size=" + str(len(window_word)))  # Size of the context window
             if window_word[0].isupper():
                 capitalization_pattern[j] = "1"
             if window_word.isupper():

--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -79,12 +79,14 @@ def extract_features(tokens: List[Token]):
         features: List[str] = []
 
         features.append("form=" + word)  # Token form
+        features.append("suf4=" + word[-3:])
         features.append("suf3=" + word[-3:])
         features.append("suf2=" + word[-2:])
         features.append("suf1=" + word[-1:])
         features.append("pre1=" + word[0:1])
         features.append("pre2=" + word[0:2])
         features.append("pre3=" + word[0:3])
+        features.append("pre4=" + word[0:4])
         features.append("capitalized=" + str(word[0].isupper()))  # Is the first letter capitalized?
         features.append("uppercase=" + str(word.isupper()))  # Is the token all uppercase?
         features.append("hasdigit=" + str(any(c.isdigit() for c in word)))  # Does the token contain a digit?
@@ -94,19 +96,35 @@ def extract_features(tokens: List[Token]):
         features.append("form_lower=" + word.lower())  # Lowercase form of the token
         features.append("pos_tag=" + pos_tag)  # POS tag of the token
 
-        if k > 0:
-            tPrev = tokens[k - 1][0]
-            features.append("formPrev=" + tPrev)  # Token form of previous token
-            features.append("suf3Prev=" + tPrev[-3:])  # Suffix of previous token ???
-        else:
-            features.append("BoS")  # Beginning of Sentence
+        if k == 0:
+            features.append("BoS")
+        if k == len(tokens) - 1:
+            features.append("EoS")
 
-        if k < len(tokens) - 1:
-            tNext = tokens[k + 1][0]
-            features.append("formNext=" + tNext)  # Token form of next token
-            features.append("suf3Next=" + tNext[-3:])  # Suffix of previous token ???
-        else:
-            features.append("EoS")  # End of Sentence
+        capitalization_pattern = ["0"] * 5  # Initialize capitalization pattern
+        uppercase_pattern = ["0"] * 5  # Initialize uppercase pattern
+        hasdigit_pattern = ["0"] * 5  # Initialize digit pattern
+        hashyphen_pattern = ["0"] * 5  # Initialize hyphen pattern
+        for j, i in enumerate(range(-2, 3)):
+            if k + i < 0 or k + i >= len(tokens):
+                continue
+            window_word = tokens[k + i][0]
+            if i != 0:
+                features.append("window" + str(i) + "=" + window_word.lower())  # Context window features
+                features.append("window-" + str(i) + "-size=" + str(len(window_word)))  # Size of the context window
+            if window_word[0].isupper():
+                capitalization_pattern[j] = "1"
+            if window_word.isupper():
+                uppercase_pattern[j] = "1"
+            if any(c.isdigit() for c in window_word):
+                hasdigit_pattern[j] = "1"
+            if "-" in window_word:
+                hashyphen_pattern[j] = "1"
+
+        features.append("neigh-capitalization=" + "".join(capitalization_pattern))  # Capitalization pattern
+        features.append("neigh-uppercase=" + "".join(uppercase_pattern))  # Uppercase pattern
+        features.append("neigh-hasdigit=" + "".join(hasdigit_pattern))  # Digit pattern
+        features.append("neigh-hashyphen=" + "".join(hashyphen_pattern))  # Hyphen pattern
 
         result.append(features)
 

--- a/ml/extract-features.py
+++ b/ml/extract-features.py
@@ -74,6 +74,18 @@ def extract_features(tokens: List[Token]):
 
         features.append("form=" + token)  # Token form
         features.append("suf3=" + token[-3:])
+        features.append("suf2=" + token[-2:])
+        features.append("suf1=" + token[-1:])
+        features.append("pre1=" + token[0:1])
+        features.append("pre2=" + token[0:2])
+        features.append("pre3=" + token[0:3])
+        features.append("capitalized=" + str(token[0].isupper()))  # Is the first letter capitalized?
+        features.append("uppercase=" + str(token.isupper()))  # Is the token all uppercase?
+        features.append("hasdigit=" + str(any(c.isdigit() for c in token)))  # Does the token contain a digit?
+        features.append("haspunct=" + str(any(c in ".,;:!?" for c in token)))  # Does the token contain punctuation?
+        features.append("hashyphen=" + str("-" in token))  # Does the token contain a hyphen?
+        features.append("length=" + str(len(token)))  # Length of the token
+        features.append("form_lower=" + token.lower())  # Lowercase form of the token
 
         if k > 0:
             tPrev = tokens[k - 1][0]


### PR DESCRIPTION
Building upon pull request #4, which contains the following features:

* Suffixes and preffixes of lengths 1, 2, and 3
* A flag for whether the word is capitalized
* A flag for whether the word is all uppercase
* A flag for whether the word contains a digit
* A flag for whether the word contains any form of punctuation (`.,;:!?`)
* A flag for whether the word contains a hyphen
* The length of the word
* The word in lowercase
* The PoS that the word is, as reported by `nltk`'s PoS tagger
 
 This pull request adds the following:
* Increased the suffixes and prefixes lengths from 1, 2, 3 to 1, 2, 3, 4.
* Increased the context window size from 3 (left, center, right) to 5.
* Added neighbor sizes (for each of the four neighbors)
* Neighbor capitalization pattern (bitwise code that holds whether each of the neighbors in the window are or not capitalized)
* Neighbor uppercase pattern (bitwise code that holds whether each of the neighbors in the window are or not uppercase)
* Neighbor has digit pattern (bitwise code that holds whether each of the neighbors in the window contain a digit)
* Neighbor has hyphen pattern (bitwise code that holds whether each of the neighbors in the window contain a cyphen)


For example, in the following sentence:
```txt
Doctor House likes vicodin 1G
```
for word `likes` would yield the following features for the neighborhoods.
```
window-2=Doctor
window-1=House
window1=vicodin
window2=1G

window-2-size=6
window-1-size=5
window1-size=7
window2-size=2

neigh-capitalization=11000
neigh-uppercase=00001 
neigh-hasdigit=00001
neigh-hashyphen=00000
```

**Note that '1G'.isupper() returns True even though '1'.isupper() is False.**
![image](https://github.com/user-attachments/assets/d70c0865-be97-4f68-aad5-f569cc71d47b)

